### PR TITLE
2.0

### DIFF
--- a/src/chrome/background.js
+++ b/src/chrome/background.js
@@ -74,7 +74,7 @@ module.exports = {
         case (enums.messageTypes.update): {
 
           if (sender.tab && sender.tab.id && sender.tab.url) {
-            Sessions.updateName(sender.tab.id, sender.tab.url, request.name);
+            Sessions.updateName(sender.tab.id, sender.tab.url, request.name, request.redirectedFrom);
           } else {
             console.error('Received malformed update message: ' +
                           JSON.stringify(request) + ', ' + JSON.stringify(sender));

--- a/src/chrome/session-handler.js
+++ b/src/chrome/session-handler.js
@@ -190,12 +190,12 @@ module.exports = {
    * @param url - url of the page to update
    * @param name - cleaned name to update
    */
-  updateName: function(tabId, url, name) {
+  updateName: function(tabId, url, name, redirectedFrom) {
     var session = _.find(this.activeSessions, function(s) {
       return _.contains(s.tabs, tabId);
     });
 
-    Storage.updatePageName(session.id, url, name);
+    Storage.updatePageName(session.id, url, name, redirectedFrom);
   },
 
   /**

--- a/src/chrome/storage.js
+++ b/src/chrome/storage.js
@@ -87,12 +87,32 @@ module.exports = {
    * @return {string} url with wikipedia stuff removed
    */
   shortenURL: function(url) {
-    return /[^/]*$/.exec(url)[0];
+    return decodeURI(/[^/]*$/.exec(url)[0]);
   },
 
-  updatePageName: function(sessionId, url, name) {
+  /**
+   * Update the initial page name derived from the URL to the name
+   * from the update sent via content script.
+   * @param sessionId
+   * @param url
+   * @param name
+   * @param redirectedFrom
+   */
+  updatePageName: function(sessionId, url, name, redirectedFrom) {
     var tree = JSON.parse(localStorage.getItem(sessionId));
-    var page = this.findNodeByURL(tree, url);
+    var page;
+
+    if (redirectedFrom) {
+      console.log('redirected from : ' + redirectedFrom);
+      page = this.findNodeByURL(tree, redirectedFrom);
+    } else {
+      page = this.findNodeByURL(tree, url);
+    }
+
+    // if we got redirected, update the URL, too
+    if (page && redirectedFrom) {
+      page.url = url;
+    }
 
     if (page) {
       page.name = name;

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -1,10 +1,26 @@
 'use strict';
 
 var enums = require('../chrome/enums');
+var redirectedFrom;
 
 var cleanedTitle = document.title.replace(' - Wikipedia, the free encyclopedia', '');
+var redirect = document.getElementById('contentSub').getElementsByClassName('mw-redirectedfrom');
+
+// damn wikipedia why you got to change the url format here and make me
+// do all this tedious string manipulation?
+if (redirect.length > 0) {
+  redirectedFrom = redirect[0].children[0].href;
+  redirectedFrom = redirectedFrom.split('index.php?title=');
+
+  if (redirectedFrom.length > 0) {
+    redirectedFrom[0] = redirectedFrom[0].replace('wikipedia.org/w/', 'wikipedia.org/wiki/');
+    redirectedFrom[1] = redirectedFrom[1].replace('&redirect=no', '');
+    redirectedFrom = redirectedFrom[0] + redirectedFrom[1];
+  }
+}
 
 chrome.runtime.sendMessage({
   'type': enums.messageTypes.update,
-  'name': cleanedTitle
+  'name': cleanedTitle,
+  'redirectedFrom': redirectedFrom
 });

--- a/src/web/js/router.js
+++ b/src/web/js/router.js
@@ -17,11 +17,19 @@ var HistoryListView = require('./views/history');
 module.exports = Backbone.Router.extend({
 
   routes: {
-    '': 'title',
+    '': 'checkForLatest',
     title: 'title',
     latest: 'latest',
     'history?=:sessionId': 'historyParser',
     history: 'historyList'
+  },
+
+  checkForLatest: function() {
+    if (App.StorageCollection.getLatest()) {
+      this.latest();
+    } else {
+      this.title();
+    }
   },
 
   title: function() {

--- a/src/web/styles/d3tree.less
+++ b/src/web/styles/d3tree.less
@@ -9,18 +9,24 @@
 }
 
 .label {
-  font-size: 0.6em;
+  font-size: 0.7em;
   text-align: center;
   word-wrap: normal;
 }
 
 path.link {
   fill: none;
-  stroke: @dark-grey;
+  stroke: @light-grey;
   stroke-width: 1.5px;
 }
 
 a.node, a.node:visited, a.node:hover, a.node:active {
   text-decoration: none;
+  // a dirty, dirty hack to emulate a 2px text border
+  // since there's no supported CSS3 directive for it...
+  text-shadow: 0 0 2px @white, 0 0 2px @white, 0 0 2px @white,
+               0 0 2px @white, 0 0 2px @white, 0 0 2px @white,
+               0 0 2px @white, 0 0 2px @white, 0 0 2px @white,
+               0 0 2px @white, 0 0 2px @white, 0 0 2px @white;
   color: @black;
 }


### PR DESCRIPTION
- Fix bug where if a page redirected within Wikipedia, the URL mismatch caused the name update sent from the content script to fail.
- Fix bug where if you visited the same page a second (or more) time in the same session, the node search algorithm would find the first one and return it, preventing the later nodes from updating their page name from the content script.
- When launching the app, set the default page to the latest tree if one exists, otherwise direct to the title page.
- Add a white border around node label text to offset it from the connecting lines, improving readability for long names that overlap the connecting lines.