### PR TITLE
Set `persistent: false` for background script

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,10 @@
   "author": "Patrick McCarthy",
   "homepage_url": "http://www.github.com/ptmccarthy/wikimapper",
 
-  "background": { "scripts": ["background.js"] },
+  "background": {
+    "scripts": ["background.js"],
+    "persistent": false
+  },
 
   "permissions": [
     "tabs",


### PR DESCRIPTION
Changes necessary to enable a non-persistent background script. Initial testing looks good, but might let my dev build have some more soak time to be sure.

Will resolve #86 when merged.